### PR TITLE
optimized showTask.js page - reducing clicks

### DIFF
--- a/src/components/newTask.js
+++ b/src/components/newTask.js
@@ -1,25 +1,23 @@
-import {Form} from "react-router-dom"
+import { Form } from 'react-router-dom'
 
-function NewTask({handleNewTask}) {
-    return (
-        <Form onSubmit={handleNewTask} className='new-task-form flex'>
-                <div className="task-field flex">
-                    <label> Description</label>
-                    <textarea className="border-corner" name='task' placeholder="Enter task description"/>
-                </div>
-                <div className="task-field flex">
-                    <label>Priority</label>
-                    <select name='priority' className="border-corner">
-                        <option value="1">High</option>
-                        <option value="2">Medium</option>
-                        <option value="3">Low</option>
-                    </select>
-                </div>
-                <div >
-                    <input className="task-field border-corner create-task-button" type='submit' value='Create Task' />
-                </div>
-        </Form>
-    )
+function NewTask({ handleNewTask }) {
+  return (
+    <div className="new-task-container">
+      <Form onSubmit={handleNewTask} className="new-task-form flex">
+        <div className="new-task-label">New task: </div>
+        <input className="task-name" name="task" />
+        <div className="new-task-label">Priority:</div>
+        <select name="priority" className="border-corner">
+          <option value="1">High</option>
+          <option value="2">Medium</option>
+          <option value="3" selected="selected">
+            Low
+          </option>
+        </select>
+        <input type="submit" value="Create New Task" />
+      </Form>
+    </div>
+  )
 }
 
 export default NewTask

--- a/src/index.css
+++ b/src/index.css
@@ -75,27 +75,35 @@ nav {
   color: inherit;
 }
 
-.new-project-container {
+.new-project-container,
+.new-task-container {
   width: 100%;
-  background-color: var(--pri-bright);
   display: flex;
   flex-direction: row;
   justify-content: center;
   padding: 8px;
 }
+.new-project-container {
+  background-color: var(--pri-bright);
+}
 
-.new-project-form {
+.new-project-form,
+.new-task-form {
   padding: 0px 6px;
   display: flex;
   flex-direction: row;
   justify-content: space-evenly;
+  align-items: center;
 }
 
-.new-project-form > input {
+.new-project-form > input,
+.new-task-form > input,
+.new-task-form > select {
   min-height: 18px;
   margin: 0px 8px;
 }
-.new-project-label {
+.new-project-label,
+.new-task-label {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -237,12 +245,11 @@ nav {
   text-align: right;
 }
 
-.project-card-title .project-button #project-due-date{
+.project-card-title .project-button #project-due-date {
   margin-top: 4px;
-  color:#F42272;
+  color: #f42272;
   opacity: 90%;
   font-size: 0.75rem;
-
 }
 
 .green {
@@ -264,55 +271,23 @@ nav {
   background-color: white;
   color: #333;
   margin-bottom: 10px;
-  width: auto; 
+  width: auto;
   transition: all 0.3s ease;
 }
 
 .new-task-button:hover {
-  box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
   background-color: #d9d4d4;
 }
 
+.new-task-container {
+  display: flex;
+  padding: 8px 16px;
+}
+
 .new-task-form {
-  flex-direction: column;
+  flex-direction: row;
   text-align: left;
-}
-
-.new-task-button, .new-task-form {
-  margin-left: 20px;
-}
-
-.task-field {
-  flex-direction: column;
-  margin-bottom: 10px;
-}
-
-.new-task-button, .task-field {
-  width: 300px;
-}
-
-.task-field label {
-  font-weight: bold;
-}
-
-.task-field textarea {
-  height: 80px;
-  padding: 8px;
-  resize: none;
-}
-
-.task-field select {
-  padding: 8px 0;
-  font-size: 0.9em;
-  
-}
-
-.create-task-button {
-  background-color: #a9a6a6;
-  padding: 8px 90px;
-  margin-bottom: 20px;
-  border: none;
-  font-size: 0.9em;
 }
 
 .task-show-container {
@@ -357,10 +332,12 @@ button {
   transition: background-color 0.3s ease;
 }
 
-.update-button, .delete-button {
+.update-button,
+.delete-button {
   background-color: #e3e0e0;
 }
 
-.update-button:hover, .delete-button:hover {
+.update-button:hover,
+.delete-button:hover {
   background-color: #aba9a9;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -335,9 +335,56 @@ button {
 .update-button,
 .delete-button {
   background-color: #e3e0e0;
+  border: 0px;
 }
 
 .update-button:hover,
 .delete-button:hover {
   background-color: #aba9a9;
+}
+
+.task-show-name-container,
+.task-show-priority-container,
+.task-show-status-container {
+  display: flex;
+  margin: 6px 0px;
+}
+
+.task-show-name-container {
+  width: 100%;
+}
+.task-show-name-label,
+.task-show-status-label,
+.task-show-priority-label {
+  min-width: 8ch;
+}
+.task-show-name {
+  width: 100%;
+}
+.task-show-bottom-row-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.task-show-dropdowns-container {
+  display: flex;
+}
+
+.task-show-status-label {
+}
+.task-show-status {
+}
+
+.task-show-priority-label {
+  margin-left: 40px;
+}
+.task-show-priority {
+}
+
+.task-show-buttons-container {
+  display: flex;
+}
+.task-show-buttons-container > * {
+  margin: 8px;
 }

--- a/src/pages/ProjectShow.js
+++ b/src/pages/ProjectShow.js
@@ -1,112 +1,106 @@
-import { useLoaderData, useParams } from "react-router-dom"
-import { useEffect, useState } from "react"
-import GroupedTask from "../components/groupedTask"
-import { projectLoader } from "../loaders"
-import NewTask from "../components/newTask"
+import { useLoaderData, useParams } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+import GroupedTask from '../components/groupedTask'
+import { projectLoader } from '../loaders'
+import NewTask from '../components/newTask'
 
 function ProjectShow() {
-    const [projectTasks, setProjectTasks] = useState(useLoaderData())
-    const params = useParams() // gives {id: '<id>'}
-    const [addTasks, setAddTasks] = useState(false)
-    const [buttonClicked, setButtonClicked] = useState(false) // for adding new task
-    
-    const URL = process.env.REACT_APP_URL
+  const [projectTasks, setProjectTasks] = useState(useLoaderData())
+  const params = useParams() // gives {id: '<id>'}
+  const [addTasks, setAddTasks] = useState(false)
+  const [buttonClicked, setButtonClicked] = useState(false) // for adding new task
 
-    useEffect(() => {
-        // Wrapping the call in a function since useEffect cannot directly accept an async function
-        const fetchProjectTasks = async () => {        
-            const data = await projectLoader({ params: params }) // creating params in the expected structure, that is, {params: {id: '<id>'}}
-            setProjectTasks(data) // Update state with fetched data
+  const URL = process.env.REACT_APP_URL
 
-            setAddTasks(false)
-        }
-        // Check if addTasks is true before fetching updated tasks
-        if (addTasks) {
-            fetchProjectTasks().catch(console.error) // Call the async function and catch any potential errors
-        }
+  useEffect(() => {
+    // Wrapping the call in a function since useEffect cannot directly accept an async function
+    const fetchProjectTasks = async () => {
+      const data = await projectLoader({ params: params }) // creating params in the expected structure, that is, {params: {id: '<id>'}}
+      setProjectTasks(data) // Update state with fetched data
 
-    }, [addTasks])
-
-    async function handleNewTask(event) {
-        event.preventDefault()
-
-        const formData = new FormData(event.target)
-        const createdTask = {
-            task: formData.get('task'),
-            priority: formData.get('priority'),
-
-            // using the first object since 'projectId' and 'project' field will have same value across all subtasks for a particular project
-            projectId: params['id'],
-            project: projectTasks?.[0]['project'] || "",
-
-            status: 'toDo'  // by default any new task will have 'toDo' status
-        }
-
-            
-        await fetch(`${URL}/projects/tasks`, {
-            method: 'post',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify(createdTask)
-        })
-
-
-        // anotther way to get updated list
-        //To get the newly created task along with all fields added at the backend like mongodb _id, here using the response body. The response sent from server after the POST request, includes the status code, headers, and a body (check backend TaskController.js Post request). The body of the response contains the newly created resource (in this case, the task), including any additional properties that the backend server has added
-        // const newTaskWithId = await response.json()
-
-        // Update state with the newly created task
-        // creating a new array so that memory reference to projectTasks changes and React detects this as a change in state variable
-        // setProjectTasks((prevTasks) => [...prevTasks, newTaskWithId])
-
-        // Note: Multiple state variable changes one after other like done below are usually queued and react optmizes re-rendering by looking at all queued staten variables changes
-
-        // reset buttonClicked to hide the form after submission
-        setButtonClicked(false)
-
-        // setting add tasks state to true, so that page is re-rendered with the mongodb _id using useEffect callback
-        setAddTasks(true)
-      
-        setProjectTasks(null)  // for smoother rendering so that Virtual DOM now has to compare null to the new rendered component
-
+      setAddTasks(false)
     }
-    
+    // Check if addTasks is true before fetching updated tasks
+    if (addTasks) {
+      fetchProjectTasks().catch(console.error) // Call the async function and catch any potential errors
+    }
+  }, [addTasks])
 
-    // grouping subtasks of a project based on its status
+  async function handleNewTask(event) {
+    event.preventDefault()
 
-        const todoTasks = projectTasks?.filter((item) => { 
-            return item['status'] === 'toDo'})
-        const inProgressTasks = projectTasks?.filter((item) => { 
-            return item['status'] === 'inProgress'})
-        const completedTasks = projectTasks?.filter((item) => { 
-            return item['status'] === 'completed'})
-    
+    const formData = new FormData(event.target)
+    const createdTask = {
+      task: formData.get('task'),
+      priority: formData.get('priority'),
 
+      // using the first object since 'projectId' and 'project' field will have same value across all subtasks for a particular project
+      projectId: params['id'],
+      project: projectTasks?.[0]['project'] || '',
 
-    return (
-        <div className="project-show">
-             { projectTasks && 
-            <h1 className="project-name-show">{projectTasks?.[0]?.['project']}</h1>
-             }
-            <button className='new-task-button flex border-corner' onClick={() => {setButtonClicked(true)}}>
+      status: 'toDo' // by default any new task will have 'toDo' status
+    }
+
+    await fetch(`${URL}/projects/tasks`, {
+      method: 'post',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(createdTask)
+    })
+
+    // anotther way to get updated list
+    //To get the newly created task along with all fields added at the backend like mongodb _id, here using the response body. The response sent from server after the POST request, includes the status code, headers, and a body (check backend TaskController.js Post request). The body of the response contains the newly created resource (in this case, the task), including any additional properties that the backend server has added
+    // const newTaskWithId = await response.json()
+
+    // Update state with the newly created task
+    // creating a new array so that memory reference to projectTasks changes and React detects this as a change in state variable
+    // setProjectTasks((prevTasks) => [...prevTasks, newTaskWithId])
+
+    // Note: Multiple state variable changes one after other like done below are usually queued and react optmizes re-rendering by looking at all queued staten variables changes
+
+    // reset buttonClicked to hide the form after submission
+    setButtonClicked(false)
+
+    // setting add tasks state to true, so that page is re-rendered with the mongodb _id using useEffect callback
+    setAddTasks(true)
+
+    setProjectTasks(null) // for smoother rendering so that Virtual DOM now has to compare null to the new rendered component
+  }
+
+  // grouping subtasks of a project based on its status
+
+  const todoTasks = projectTasks?.filter(item => {
+    return item['status'] === 'toDo'
+  })
+  const inProgressTasks = projectTasks?.filter(item => {
+    return item['status'] === 'inProgress'
+  })
+  const completedTasks = projectTasks?.filter(item => {
+    return item['status'] === 'completed'
+  })
+
+  return (
+    <div className="project-show">
+      {projectTasks && <h1 className="project-name-show">{projectTasks?.[0]?.['project']}</h1>}
+      {/* <button className='new-task-button flex border-corner' onClick={() => {setButtonClicked(true)}}>
                 <i class="fa-sharp fa-light fa-plus"> Add a new task </i>
             </button>
 
            { buttonClicked ? 
-           <NewTask handleNewTask={handleNewTask} />  : null }
-            
-            {projectTasks &&
-            <div className="project-show-task flex">
-                <GroupedTask tasks={todoTasks} heading={"To do"}/>
-                <GroupedTask tasks={inProgressTasks} heading={"In progress"}/>
-                <GroupedTask tasks={completedTasks} heading={"Completed"}/>
-            
-            </div>
-              }
+           <NewTask handleNewTask={handleNewTask} />
+           : null } */}
+      <NewTask handleNewTask={handleNewTask} />
+
+      {projectTasks && (
+        <div className="project-show-task flex">
+          <GroupedTask tasks={todoTasks} heading={'To do'} />
+          <GroupedTask tasks={inProgressTasks} heading={'In progress'} />
+          <GroupedTask tasks={completedTasks} heading={'Completed'} />
         </div>
-        
-    )
+      )}
+    </div>
+  )
 }
 
 export default ProjectShow

--- a/src/pages/TaskShow.js
+++ b/src/pages/TaskShow.js
@@ -98,13 +98,14 @@ function TaskShow() {
           </div>
           <div className="task-show-buttons-container">
             <div className="update-button-container">
+              {/* the update button doesn't work yet because it needs an update function in actions.js */}
               <input className="update-button" type="submit" value="Update" />
             </div>
-            <Form action={`/projects/${taskData.projectId}/tasks/delete/${taskData._id}`} method="post">
-              <input className="delete-button" type="submit" value="Delete" />
-            </Form>
           </div>
         </div>
+      </Form>
+      <Form action={`/projects/${taskData.projectId}/tasks/delete/${taskData._id}`} method="post">
+        <button className="delete-button">Delete</button>
       </Form>
     </div>
   )

--- a/src/pages/TaskShow.js
+++ b/src/pages/TaskShow.js
@@ -1,45 +1,113 @@
-import { useLoaderData } from "react-router-dom"
-import { Form } from "react-router-dom"
-import {priorityNumberToString, prettifyStatus} from "../utils/utilFunctions"
+import { useLoaderData } from 'react-router-dom'
+import { Form } from 'react-router-dom'
+import { priorityNumberToString, prettifyStatus } from '../utils/utilFunctions'
 
 function TaskShow() {
-    const taskData = useLoaderData()
-    
-    const [priorityLabel, priorityColor] = priorityNumberToString(taskData['priority'])
+  const taskData = useLoaderData()
 
-    const status = prettifyStatus(taskData['status'])
+  const [priorityLabel, priorityColor] = priorityNumberToString(taskData['priority'])
 
-    return (
-        <div className="task-show-container flex">
-            <div className='task-show-content'>
-                <div className='project-name-task task-flex'>
-                    <h2>Project:</h2>
-                    <p>{taskData['project']}</p>
-                </div>
-                <div className='task-description task-flex'>
-                    <h2>Task:</h2>
-                    <p>{taskData['task']}</p>
-                </div>
-                <div className='task-status task-flex'>
-                    <h2>Status:</h2>
-                    <p>{status}</p>
-                </div>
-                <div className='task-priority task-flex'>
-                    <h2>Priority:</h2>
-                    <p className='task-priority'>{priorityLabel}</p>
-                </div>
-            </div>
+  const status = prettifyStatus(taskData['status'])
 
-            <div className='update-delete'>
-                <button className="update-button" >Edit </button>
-                    
-                <Form action={`/projects/${taskData.projectId}/tasks/delete/${taskData._id}`} method='post'>
-                    <button className="delete-button">Delete</button>
-                </Form>
-            </div>
-        
+  let statusSelection = {
+    toDo: false,
+    inProgress: false,
+    completed: false
+  }
+
+  let prioritySelection = {
+    high: false,
+    medium: false,
+    low: false
+  }
+
+  console.log(taskData)
+
+  if (taskData.status === 'toDo') {
+    statusSelection.toDo = true
+  } else if (taskData.status === 'inProgress') {
+    statusSelection.inProgress = true
+  } else if (taskData.status === 'inProgress') {
+    statusSelection.inProgress = true
+  }
+
+  if (taskData.priority === '1') {
+    prioritySelection.high = true
+  } else if (taskData.priority === '2') {
+    prioritySelection.medium = true
+  } else if (taskData.priority === '3') {
+    prioritySelection.low = true
+  }
+
+  return (
+    <div className="task-show-container flex">
+      {/* <div className="task-show-content">
+        <div className="project-name-task task-flex">
+          <h2>Project:</h2>
+          <p>{taskData['project']}</p>
         </div>
-    )
+        <div className="task-description task-flex">
+          <h2>Task:</h2>
+          <p>{taskData['task']}</p>
+        </div>
+        <div className="task-status task-flex">
+          <h2>Status:</h2>
+          <p>{status}</p>
+        </div>
+        <div className="task-priority task-flex">
+          <h2>Priority:</h2>
+          <p className="task-priority">{priorityLabel}</p>
+        </div>
+      </div> */}
+      <Form action={`/projects/${taskData.projectId}/tasks/${taskData._id}`} method="post">
+        <div className="task-show-name-container">
+          <div className="task-show-name-label"> Task: </div>
+          <input className="task-show-name" type="text" value={taskData.task} />
+        </div>
+
+        <div className="task-show-bottom-row-container">
+          <div className="task-show-dropdowns-container">
+            <div className="task-show-status-container">
+              <div className="task-show-status-label"> Status: </div>
+              <select className="task-show-status">
+                <option value="toDo" selected={statusSelection.toDo}>
+                  To Do
+                </option>
+                <option value="inProgress" selected={statusSelection.inProgress}>
+                  In Progress
+                </option>
+                <option value="completed" selected={statusSelection.completed}>
+                  Completed
+                </option>
+              </select>
+            </div>
+            <div className="task-show-priority-container">
+              <div className="task-show-priority-label"> Priority: </div>
+              <select className="task-show-priority">
+                <option value="1" selected={prioritySelection.high}>
+                  High
+                </option>
+                <option value="2" selected={prioritySelection.medium}>
+                  Medium
+                </option>
+                <option value="3" selected={prioritySelection.low}>
+                  Low
+                </option>
+              </select>
+            </div>
+          </div>
+          <div className="task-show-buttons-container">
+            <div className="update-button-container">
+              <input className="update-button" type="submit" value="Update" />
+            </div>
+            <Form action={`/projects/${taskData.projectId}/tasks/delete/${taskData._id}`} method="post">
+              <input className="delete-button" type="submit" value="Delete" />
+            </Form>
+          </div>
+        </div>
+      </Form>
+    </div>
+  )
 }
 
 export default TaskShow


### PR DESCRIPTION
Issue: show page has no good reason to exist. If the user wants to edit, they have to press edit to be taken to another page. They're better off editing it right as they see the task's page.
Solution: the show page pre-populates the subtask's properties. task is shown in a text field and status and priority fields are shown in drop down menus (they are pre-selected to the subtask's previous setting).

Known issues:
1. project name needs to be repositioned to be consistent to the project page
2. update button doesn't work yet. it needs a function in actions.js
3. needs better dynamic css styling